### PR TITLE
Allow can0 to be used for socketcan

### DIFF
--- a/src/can_socketcan.rs
+++ b/src/can_socketcan.rs
@@ -42,8 +42,7 @@ impl Drop for SocketCanNetwork {
 
 impl SocketCanNetwork {
     pub fn new(bus: u8, id: &'static str) -> Self {
-        // remember, the owa4x starts at can1 instead of can0
-        let bus = bus + 1;
+        // note, the owa4x starts at can1 instead of can0
         debug!("Initializing bus #{}", bus);
         let bus_id = format!("{}{}", id, bus);
         debug!("Opening bus number {} - id: {}", bus, bus_id);


### PR DESCRIPTION
The socketcan bus number was incremented in SocketCanNetwork::new, preventing use of can0:
```rust
// remember, the owa4x starts at can1 instead of can0
let bus = bus + 1;
```
I've removed the increment to give more predictable behavior.